### PR TITLE
Give Curator ability to search through their catalog

### DIFF
--- a/lib/curator.rb
+++ b/lib/curator.rb
@@ -1,3 +1,4 @@
+require 'pry'
 class Curator
   attr_reader :artists, :photographs
 
@@ -26,5 +27,11 @@ class Curator
       end
     end
   ph_by_ph
+  end
+
+  def artists_with_multiple_photographs
+    list = []
+    photographs_by_artist.find_all{|artist, works| list << artist if works.length > 1}
+    list.map{|artist| artist.name}
   end
 end

--- a/lib/curator.rb
+++ b/lib/curator.rb
@@ -34,4 +34,12 @@ class Curator
     photographs_by_artist.find_all{|artist, works| list << artist if works.length > 1}
     list.map{|artist| artist.name}
   end
+
+  def photographs_taken_by_artist_from(country)
+    list = []
+    photographs_by_artist.find_all do
+      |artist, works| list << works if artist.country == country
+    end
+    list.flatten
+  end
 end

--- a/lib/curator.rb
+++ b/lib/curator.rb
@@ -17,4 +17,14 @@ class Curator
   def find_artist_by_id(id)
     @artists.find{|artist| artist.id == id}
   end
+
+  def photographs_by_artist
+    ph_by_ph = Hash.new(0)
+    @artists.each do |artist|
+      ph_by_ph[artist] = @photographs.find_all do |photograph|
+        photograph.artist_id == artist.id
+      end
+    end
+  ph_by_ph
+  end
 end

--- a/spec/curator_spec.rb
+++ b/spec/curator_spec.rb
@@ -127,5 +127,7 @@ describe Curator do
     expect(@curator.artists_with_multiple_photographs).to eq(["Diane Arbus"])
   end
 
-
+  it "can determine photographs taken by artists from a given country" do
+    expect(@curator.photographs_taken_by_artist_from("United States")).to eq([@photo_2, @photo_3, @photo_4])
+  end
 end

--- a/spec/curator_spec.rb
+++ b/spec/curator_spec.rb
@@ -129,5 +129,6 @@ describe Curator do
 
   it "can determine photographs taken by artists from a given country" do
     expect(@curator.photographs_taken_by_artist_from("United States")).to eq([@photo_2, @photo_3, @photo_4])
+    expect(@curator.photographs_taken_by_artist_from("Argentina")).to eq([])
   end
 end

--- a/spec/curator_spec.rb
+++ b/spec/curator_spec.rb
@@ -58,3 +58,71 @@ describe Curator do
     expect(@curator.find_artist_by_id("1")).to eq(@artist_1)
   end
 end
+
+describe Curator do
+  before(:each) do
+    @curator = Curator.new
+    @photo_1 = Photograph.new({
+      id: "1",
+      name: "Rue Mouffetard, Paris (Boy with Bottles)",
+      artist_id: "1",
+      year: "1954"
+    })
+    @photo_2 = Photograph.new({
+      id: "2",
+      name: "Moonrise, Hernandez",
+      artist_id: "2",
+      year: "1941"
+    })
+    @photo_3 = Photograph.new({
+      id: "3",
+      name: "Identical Twins, Roselle, New Jersey",
+      artist_id: "3",
+      year: "1967"
+    })
+    @photo_4 = Photograph.new({
+      id: "4",
+      name: "Monolith, The Face of Half Dome",
+      artist_id: "3",
+      year: "1927"
+    })
+    @artist_1 = Artist.new({
+      id: "1",
+      name: "Henri Cartier-Bresson",
+      born: "1908",
+      died: "2004",
+      country: "France"
+    })
+    @artist_2 = Artist.new({
+      id: "2",
+      name: "Ansel Adams",
+      born: "1902",
+      died: "1984",
+      country: "United States"
+    })
+    @artist_3 = Artist.new({
+      id: "3",
+      name: "Diane Arbus",
+      born: "1923",
+      died: "1971",
+      country: "United States"
+    })
+    curator.add_artist(artist_1)
+    curator.add_artist(artist_2)
+    curator.add_artist(artist_3)
+    curator.add_photograph(photo_1)
+    curator.add_photograph(photo_2)
+    curator.add_photograph(photo_3)
+    curator.add_photograph(photo_4)
+  end
+
+  it "can list photographs by artist" do
+    expect(curator.photographs_by_artist).to eq({
+      @artist_1: [@photo_1]
+      @artist_2: [@photo_2]
+      @artist_3: [@photo_3, @photo_4]
+      })
+  end
+
+
+end

--- a/spec/curator_spec.rb
+++ b/spec/curator_spec.rb
@@ -123,5 +123,9 @@ describe Curator do
       @artist_3 => [@photo_3, @photo_4]})
   end
 
+  it "can determine which artists have multiple photographs" do
+    expect(@curator.artists_with_multiple_photographs).to eq(["Diane Arbus"])
+  end
+
 
 end

--- a/spec/curator_spec.rb
+++ b/spec/curator_spec.rb
@@ -107,21 +107,20 @@ describe Curator do
       died: "1971",
       country: "United States"
     })
-    curator.add_artist(artist_1)
-    curator.add_artist(artist_2)
-    curator.add_artist(artist_3)
-    curator.add_photograph(photo_1)
-    curator.add_photograph(photo_2)
-    curator.add_photograph(photo_3)
-    curator.add_photograph(photo_4)
+    @curator.add_artist(@artist_1)
+    @curator.add_artist(@artist_2)
+    @curator.add_artist(@artist_3)
+    @curator.add_photograph(@photo_1)
+    @curator.add_photograph(@photo_2)
+    @curator.add_photograph(@photo_3)
+    @curator.add_photograph(@photo_4)
   end
 
   it "can list photographs by artist" do
-    expect(curator.photographs_by_artist).to eq({
-      @artist_1: [@photo_1]
-      @artist_2: [@photo_2]
-      @artist_3: [@photo_3, @photo_4]
-      })
+    expect(@curator.photographs_by_artist).to eq({
+      @artist_1 => [@photo_1],
+      @artist_2 => [@photo_2],
+      @artist_3 => [@photo_3, @photo_4]})
   end
 
 


### PR DESCRIPTION
This merge will implement methods allowing Curator to search for photographs by their respective artists, to tell which artists have multiple photographs, and to tell which photographs were taken by artists from a specified country.

All methods are tested and working.